### PR TITLE
Add server and client testing harness and initial tests

### DIFF
--- a/client/src/components/contact.test.tsx
+++ b/client/src/components/contact.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Contact from './contact';
+import { vi } from 'vitest';
+
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }))
+}));
+
+function renderComponent() {
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <Contact />
+    </QueryClientProvider>
+  );
+}
+
+test('submits contact form', async () => {
+  const user = userEvent.setup();
+  renderComponent();
+
+  await user.type(screen.getByTestId('input-contact-name'), 'Jane');
+  await user.type(screen.getByTestId('input-contact-email'), 'jane@example.com');
+  await user.type(screen.getByTestId('textarea-contact-message'), 'Hello from space!');
+  await user.click(screen.getByTestId('button-send-message'));
+
+  const { apiRequest } = await import('@/lib/queryClient');
+  expect(apiRequest).toHaveBeenCalledWith(
+    'POST',
+    '/api/contact',
+    expect.objectContaining({ name: 'Jane' })
+  );
+});

--- a/client/src/components/reservation.test.tsx
+++ b/client/src/components/reservation.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import Reservation from './reservation';
+import { vi } from 'vitest';
+
+vi.mock('@/lib/queryClient', () => ({
+  apiRequest: vi.fn(() => Promise.resolve({ json: () => Promise.resolve({}) }))
+}));
+
+function renderComponent() {
+  const queryClient = new QueryClient();
+  const facility = {
+    id: 'fac-1',
+    name: 'Quantum Bowling',
+    type: 'bowling',
+    description: '',
+    capacity: 8,
+    hourlyRate: '45.00'
+  };
+  queryClient.setQueryData(['/api/facilities'], [facility]);
+  queryClient.setQueryData(['/api/availability', facility.id, '2099-01-01'], [
+    { time: '10:00', available: true, displayTime: '10:00 AM' }
+  ]);
+  return {
+    facility,
+    ...render(
+      <QueryClientProvider client={queryClient}>
+        <Reservation />
+      </QueryClientProvider>
+    )
+  };
+}
+
+it('submits reservation form', async () => {
+  const user = userEvent.setup();
+  const { facility } = renderComponent();
+
+  await user.click(screen.getByTestId(`facility-button-${facility.type}`));
+  await user.type(screen.getByTestId('input-date'), '2099-01-01');
+  await user.click(screen.getByTestId('select-time'));
+  await user.click(screen.getByTestId('time-slot-10:00'));
+  await user.clear(screen.getByTestId('input-party-size'));
+  await user.type(screen.getByTestId('input-party-size'), '2');
+  await user.type(screen.getByTestId('input-phone'), '1234567890');
+  await user.type(screen.getByTestId('input-name'), 'John Doe');
+  await user.type(screen.getByTestId('input-email'), 'john@example.com');
+  await user.click(screen.getByTestId('button-submit-reservation'));
+
+  const { apiRequest } = await import('@/lib/queryClient');
+  expect(apiRequest).toHaveBeenCalledWith(
+    'POST',
+    '/api/reservations',
+    expect.objectContaining({ customerName: 'John Doe' })
+  );
+});

--- a/client/test/setup.ts
+++ b/client/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/server/**/*.test.ts'],
+  moduleNameMapper: {
+    '^@shared/(.*)$': '<rootDir>/shared/$1'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test:server": "jest",
+    "test:client": "vitest run",
+    "test": "npm run test:server && npm run test:client"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -97,7 +100,15 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "@types/jest": "^29.5.12",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/user-event": "^14.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "supertest": "^6.3.4",
+    "vitest": "^1.6.0"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"

--- a/server/routes.test.ts
+++ b/server/routes.test.ts
@@ -1,0 +1,73 @@
+import express from 'express';
+import request from 'supertest';
+import { registerRoutes } from './routes';
+import { storage } from './storage';
+
+describe('API routes', () => {
+  let app: express.Express;
+  let facilityId: string;
+
+  beforeEach(async () => {
+    // reset storage
+    (storage as any).reservations.clear();
+    (storage as any).contactMessages.clear();
+    const facilities = await storage.getFacilities();
+    facilityId = facilities[0].id;
+    app = express();
+    app.use(express.json());
+    await registerRoutes(app);
+  });
+
+  describe('/api/reservations', () => {
+    const baseReservation = {
+      customerName: 'John Doe',
+      customerEmail: 'john@example.com',
+      customerPhone: '1234567890',
+      date: '2099-01-01',
+      time: '10:00',
+      duration: 1,
+      partySize: 2,
+      pricingTier: 'explorer',
+      totalCost: '0.00'
+    };
+
+    it('creates and lists reservations', async () => {
+      const res = await request(app)
+        .post('/api/reservations')
+        .send({ ...baseReservation, facilityId });
+      expect(res.status).toBe(201);
+      expect(res.body.facilityId).toBe(facilityId);
+
+      const list = await request(app).get('/api/reservations');
+      expect(list.status).toBe(200);
+      expect(list.body.length).toBe(1);
+    });
+
+    it('prevents double booking', async () => {
+      await request(app).post('/api/reservations').send({ ...baseReservation, facilityId });
+      const conflict = await request(app).post('/api/reservations').send({ ...baseReservation, facilityId });
+      expect(conflict.status).toBe(409);
+    });
+  });
+
+  describe('/api/contact', () => {
+    it('accepts contact message', async () => {
+      const res = await request(app).post('/api/contact').send({
+        name: 'Jane',
+        email: 'jane@example.com',
+        message: 'Hello from space!'
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.name).toBe('Jane');
+    });
+
+    it('validates contact message', async () => {
+      const res = await request(app).post('/api/contact').send({
+        name: '',
+        email: 'invalid',
+        message: 'short'
+      });
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -34,4 +34,9 @@ export default defineConfig({
       deny: ["**/.*"],
     },
   },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./client/test/setup.ts",
+  },
 });


### PR DESCRIPTION
## Summary
- set up Jest and Vitest test runners
- add API tests for reservations and contact endpoints
- add component tests for Reservation and Contact forms

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47c9bd7848323af9bf4928ce2623e