### PR TITLE
feat: persist data with Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# PostgreSQL connection string
+DATABASE_URL="postgresql://user:password@localhost:5432/dbname"
+
+# Optional: port for the HTTP server
+PORT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "start": "NODE_ENV=production node -r dotenv/config dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push"
   },

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,6 +1,11 @@
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set");
+}
 
 const app = express();
 app.use(express.json());

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -1,162 +1,193 @@
-import { type User, type InsertUser, type Facility, type InsertFacility, type Reservation, type InsertReservation, type ContactMessage, type InsertContactMessage } from "@shared/schema";
-import { randomUUID } from "crypto";
+import "dotenv/config";
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { and, eq } from "drizzle-orm";
+import {
+  users,
+  facilities,
+  reservations,
+  contactMessages,
+  type User,
+  type InsertUser,
+  type Facility,
+  type InsertFacility,
+  type Reservation,
+  type InsertReservation,
+  type ContactMessage,
+  type InsertContactMessage,
+} from "@shared/schema";
+import * as schema from "@shared/schema";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const sql = neon(process.env.DATABASE_URL);
+export const db = drizzle(sql, { schema });
 
 export interface IStorage {
   getUser(id: string): Promise<User | undefined>;
   getUserByUsername(username: string): Promise<User | undefined>;
   createUser(user: InsertUser): Promise<User>;
-  
+
   getFacilities(): Promise<Facility[]>;
   getFacility(id: string): Promise<Facility | undefined>;
   createFacility(facility: InsertFacility): Promise<Facility>;
-  
+
   getReservations(): Promise<Reservation[]>;
   getReservation(id: string): Promise<Reservation | undefined>;
   getReservationsByDate(date: string): Promise<Reservation[]>;
-  getReservationsByFacilityAndDate(facilityId: string, date: string): Promise<Reservation[]>;
+  getReservationsByFacilityAndDate(
+    facilityId: string,
+    date: string,
+  ): Promise<Reservation[]>;
   createReservation(reservation: InsertReservation): Promise<Reservation>;
-  updateReservation(id: string, updates: Partial<Reservation>): Promise<Reservation | undefined>;
+  updateReservation(
+    id: string,
+    updates: Partial<Reservation>,
+  ): Promise<Reservation | undefined>;
   deleteReservation(id: string): Promise<boolean>;
-  
+
   createContactMessage(message: InsertContactMessage): Promise<ContactMessage>;
 }
 
-export class MemStorage implements IStorage {
-  private users: Map<string, User>;
-  private facilities: Map<string, Facility>;
-  private reservations: Map<string, Reservation>;
-  private contactMessages: Map<string, ContactMessage>;
-
+class DbStorage implements IStorage {
   constructor() {
-    this.users = new Map();
-    this.facilities = new Map();
-    this.reservations = new Map();
-    this.contactMessages = new Map();
-    
-    // Initialize with default facilities
-    this.initializeDefaultFacilities();
+    void this.initializeDefaultFacilities();
   }
 
-  private initializeDefaultFacilities() {
-    const defaultFacilities: InsertFacility[] = [
+  private async initializeDefaultFacilities() {
+    const existing = await db.select().from(facilities).limit(1);
+    if (existing.length > 0) return;
+
+    const defaults: InsertFacility[] = [
       {
         name: "Quantum Bowling",
         type: "bowling",
-        description: "20 state-of-the-art lanes with holographic scoring systems and cosmic lighting effects",
+        description:
+          "20 state-of-the-art lanes with holographic scoring systems and cosmic lighting effects",
         capacity: 8,
         hourlyRate: "45.00",
       },
       {
         name: "Nebula Billiards",
         type: "billiards",
-        description: "12 premium tables with electromagnetic cue technology and asteroid-inspired designs",
+        description:
+          "12 premium tables with electromagnetic cue technology and asteroid-inspired designs",
         capacity: 4,
         hourlyRate: "35.00",
       },
       {
         name: "Galactic Arcade",
         type: "arcade",
-        description: "100+ cutting-edge games featuring VR, AR, and classic arcade experiences",
+        description:
+          "100+ cutting-edge games featuring VR, AR, and classic arcade experiences",
         capacity: 20,
         hourlyRate: "25.00",
       },
     ];
 
-    defaultFacilities.forEach((facility) => {
-      const id = randomUUID();
-      const newFacility: Facility = { ...facility, id };
-      this.facilities.set(id, newFacility);
-    });
+    await db.insert(facilities).values(defaults);
   }
 
   async getUser(id: string): Promise<User | undefined> {
-    return this.users.get(id);
+    return db.query.users.findFirst({ where: eq(users.id, id) });
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    return Array.from(this.users.values()).find(
-      (user) => user.username === username,
-    );
+    return db.query.users.findFirst({ where: eq(users.username, username) });
   }
 
-  async createUser(insertUser: InsertUser): Promise<User> {
-    const id = randomUUID();
-    const user: User = { ...insertUser, id };
-    this.users.set(id, user);
-    return user;
+  async createUser(user: InsertUser): Promise<User> {
+    const [created] = await db.insert(users).values(user).returning();
+    return created;
   }
 
   async getFacilities(): Promise<Facility[]> {
-    return Array.from(this.facilities.values());
+    return db.select().from(facilities);
   }
 
   async getFacility(id: string): Promise<Facility | undefined> {
-    return this.facilities.get(id);
-  }
-
-  async createFacility(insertFacility: InsertFacility): Promise<Facility> {
-    const id = randomUUID();
-    const facility: Facility = { ...insertFacility, id };
-    this.facilities.set(id, facility);
+    const [facility] = await db
+      .select()
+      .from(facilities)
+      .where(eq(facilities.id, id));
     return facility;
   }
 
+  async createFacility(facility: InsertFacility): Promise<Facility> {
+    const [created] = await db.insert(facilities).values(facility).returning();
+    return created;
+  }
+
   async getReservations(): Promise<Reservation[]> {
-    return Array.from(this.reservations.values());
+    return db.select().from(reservations);
   }
 
   async getReservation(id: string): Promise<Reservation | undefined> {
-    return this.reservations.get(id);
-  }
-
-  async getReservationsByDate(date: string): Promise<Reservation[]> {
-    return Array.from(this.reservations.values()).filter(
-      (reservation) => reservation.date === date
-    );
-  }
-
-  async getReservationsByFacilityAndDate(facilityId: string, date: string): Promise<Reservation[]> {
-    return Array.from(this.reservations.values()).filter(
-      (reservation) => reservation.facilityId === facilityId && reservation.date === date
-    );
-  }
-
-  async createReservation(insertReservation: InsertReservation): Promise<Reservation> {
-    const id = randomUUID();
-    const reservation: Reservation = {
-      ...insertReservation,
-      id,
-      duration: insertReservation.duration || 1,
-      status: insertReservation.status || "confirmed",
-      createdAt: new Date(),
-    };
-    this.reservations.set(id, reservation);
+    const [reservation] = await db
+      .select()
+      .from(reservations)
+      .where(eq(reservations.id, id));
     return reservation;
   }
 
-  async updateReservation(id: string, updates: Partial<Reservation>): Promise<Reservation | undefined> {
-    const existing = this.reservations.get(id);
-    if (!existing) return undefined;
-    
-    const updated: Reservation = { ...existing, ...updates };
-    this.reservations.set(id, updated);
+  async getReservationsByDate(date: string): Promise<Reservation[]> {
+    return db
+      .select()
+      .from(reservations)
+      .where(eq(reservations.date, date));
+  }
+
+  async getReservationsByFacilityAndDate(
+    facilityId: string,
+    date: string,
+  ): Promise<Reservation[]> {
+    return db
+      .select()
+      .from(reservations)
+      .where(
+        and(eq(reservations.facilityId, facilityId), eq(reservations.date, date)),
+      );
+  }
+
+  async createReservation(reservation: InsertReservation): Promise<Reservation> {
+    const [created] = await db
+      .insert(reservations)
+      .values(reservation)
+      .returning();
+    return created;
+  }
+
+  async updateReservation(
+    id: string,
+    updates: Partial<Reservation>,
+  ): Promise<Reservation | undefined> {
+    const [updated] = await db
+      .update(reservations)
+      .set(updates)
+      .where(eq(reservations.id, id))
+      .returning();
     return updated;
   }
 
   async deleteReservation(id: string): Promise<boolean> {
-    return this.reservations.delete(id);
+    const deleted = await db
+      .delete(reservations)
+      .where(eq(reservations.id, id))
+      .returning({ id: reservations.id });
+    return deleted.length > 0;
   }
 
-  async createContactMessage(insertMessage: InsertContactMessage): Promise<ContactMessage> {
-    const id = randomUUID();
-    const message: ContactMessage = {
-      ...insertMessage,
-      id,
-      createdAt: new Date(),
-    };
-    this.contactMessages.set(id, message);
-    return message;
+  async createContactMessage(
+    message: InsertContactMessage,
+  ): Promise<ContactMessage> {
+    const [created] = await db
+      .insert(contactMessages)
+      .values(message)
+      .returning();
+    return created;
   }
 }
 
-export const storage = new MemStorage();
+export const storage = new DbStorage();


### PR DESCRIPTION
## Summary
- connect to PostgreSQL with Drizzle ORM and replace in-memory storage
- require DATABASE_URL during server startup and document env vars
- preload environment config when starting the server

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a47c963a2c83239496474fce2438dd